### PR TITLE
Handle dead keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3072,6 +3072,11 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "native-keymap": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/native-keymap/-/native-keymap-2.2.0.tgz",
+      "integrity": "sha512-rWT9mf5f4vMGluXoIoxKSZy76fcVgMvk5jC4meBaOP2GfMJAI7Obtdzpa1Fa1qZCBtZa+OAYV8vlc8dKPOhUNw=="
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "hyperapp": "1.2.9",
     "hyperapp-feather": "0.4.0",
     "hyperapp-seti": "^0.3.0",
-    "marked": "^1.2.0"
+    "marked": "^1.2.0",
+    "native-keymap": "^2.2.0"
   },
   "devDependencies": {
     "@deomitrus/hyperapp-redux-devtools": "1.2.0",


### PR DESCRIPTION
Proof of concept PR for #8  The plan is roughly

1. If the `KeyboardEvent` returns a `Dead` key, get the actual key from the `code` using the native keyboard layout, and store it in a persistent variable.
2. If this variable is set when a key is sent to neovim, modify the key accordingly by looking up the correct composition rule.