### PR TITLE
[WIP] Use TSX w/Hyperapp instead of functions

### DIFF
--- a/src/components/command-line.tsx
+++ b/src/components/command-line.tsx
@@ -100,7 +100,7 @@ const view = ($: S) =>
         desc: $.kind === CommandType.Ex ? 'command line' : 'prompt',
         position: $.position,
         icon:
-          $.value.startsWith('lua ') && $.kind == CommandType.Ex
+          $.value.startsWith('lua ') && $.kind === CommandType.Ex
             ? Icon.Moon
             : modeSwitch.get($.kind) || Icon.Command,
       }),

--- a/src/components/command-line.tsx
+++ b/src/components/command-line.tsx
@@ -71,57 +71,47 @@ const view = ($: S) =>
     {
       position: 'relative',
     },
-    [
-      ,
-      $.prompt &&
-        h(
-          'div',
-          {
-            style: {
-              position: 'absolute',
-              width: '100%',
-              background: 'var(--background-50)',
-              marginTop: '-40px',
-              height: '40px',
-              display: 'flex',
-              alignItems: 'center',
-            },
-          },
-          [
-            ,
-            h(
-              'div',
-              {
-                style: {
-                  padding: '0 15px',
-                  fontSize: '1.1rem',
-                },
-              },
-              $.prompt
-            ),
-          ]
-        ),
 
+    [
+      $.prompt && (
+        <div
+          style={{
+            position: 'absolute',
+            width: '100%',
+            background: 'var(--background-50)',
+            marginTop: '-40px',
+            height: '40px',
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <div
+            style={{
+              padding: '0 15px',
+              fontSize: '1.1rem',
+            }}
+          ></div>
+          {$.prompt}
+        </div>
+      ),
       Input({
         focus: true,
         value: $.value,
-        desc: $.kind == CommandType.Ex ? 'command line' : 'prompt',
+        desc: $.kind === CommandType.Ex ? 'command line' : 'prompt',
         position: $.position,
-        icon: (($.value).startsWith('lua ') && $.kind == CommandType.Ex) ? Icon.Moon : (modeSwitch.get($.kind) || Icon.Command),
+        icon:
+          $.value.startsWith('lua ') && $.kind == CommandType.Ex
+            ? Icon.Moon
+            : modeSwitch.get($.kind) || Icon.Command,
       }),
 
-      h(
-        'div',
-        $.options.map((name, ix) =>
-          h(
-            RowNormal,
-            {
-              active: ix === $.ix,
-            },
-            [, h('div', name)]
-          )
-        )
-      ),
+      <div>
+        {$.options.map((name, ix) => (
+          <RowNormal active={ix === $.ix}>
+            <div>{name}</div>
+          </RowNormal>
+        ))}
+      </div>,
     ]
   )
 

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -10,6 +10,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "sourceMap": true,
-    "plugins": [{ "transform": "../tools/transform-no-dev.js" }]
+    "plugins": [{ "transform": "../tools/transform-no-dev.js" }],
+    "jsx": "react",
+    "jsxFactory": "h"
   }
 }


### PR DESCRIPTION
ATM this is just a proof-of-concept, will want to change functions like `Plugin` to be able to be used as TSX tags themselves, e.g. `<Plugin someopt={somevariable}></Plugin>`.

One thing to look into is performance once everything is ported; it *should* be the same, but will want to make fairly sure there aren't any regressions there (or if there are, that they are mostly insignificant).