### PR TITLE
Improve external popup menu appearance

### DIFF
--- a/src/components/nvim/autocomplete.tsx
+++ b/src/components/nvim/autocomplete.tsx
@@ -242,8 +242,7 @@ const Autocomplete = ({
                 style={{
                   display: 'flex',
                   // TODO: this doesn't scale with font size?
-                  width: '24px',
-                  'margin-right': '2px',
+                  width: '16',
                   'align-items': 'center',
                   'justify-content': 'center',
                 }}

--- a/src/components/nvim/autocomplete.tsx
+++ b/src/components/nvim/autocomplete.tsx
@@ -189,6 +189,13 @@ const docs = (data: string) => (
   />
 )
 
+const tdStyle: CSSProperties = {
+  'padding-right': '8px',
+  'line-height': cvar('line-height'),
+  'font-family': 'var(--font)',
+  'font-size': 'var(--font-size)px',
+}
+
 const Autocomplete = ({
   documentation,
   x,
@@ -218,15 +225,20 @@ const Autocomplete = ({
         style={{
           background: cvar('background-30'),
           display: 'flex',
+          overflow: 'hidden',
           'flex-direction': 'row',
-          'overflow-y': 'hidden',
           'max-height': `${workspace.cell.height * visibleOptions}px`,
         }}
       >
-        <div>
-          {options.map(({ text, kind }, id) => (
-            <RowComplete active={id === ix}>
-              <div
+        <table style={{ overflow: 'hidden' }}>
+          {options.map(({ text, kind, menu }, id) => (
+            <tr
+              style={{
+                color:
+                  id === ix ? cvar('foreground-b20') : cvar('foreground-30'),
+              }}
+            >
+              <td
                 style={{
                   display: 'flex',
                   // TODO: this doesn't scale with font size?
@@ -237,19 +249,12 @@ const Autocomplete = ({
                 }}
               >
                 {getCompletionIcon(kind)}
-              </div>
-              <div>{text}</div>
-            </RowComplete>
+              </td>
+              <td style={tdStyle}>{text}</td>
+              <td style={tdStyle}>{menu}</td>
+            </tr>
           ))}
-        </div>
-
-        <div>
-          {options.map(({ menu }, id) => (
-            <RowComplete active={id === ix}>
-              <div>{menu}</div>
-            </RowComplete>
-          ))}
-        </div>
+        </table>
       </div>
       {documentation && (
         <div id='autocopmlete-docs-sup-yo'>{docs(documentation)}</div>

--- a/src/components/nvim/autocomplete.tsx
+++ b/src/components/nvim/autocomplete.tsx
@@ -217,28 +217,39 @@ const Autocomplete = ({
       <div
         style={{
           background: cvar('background-30'),
+          display: 'flex',
+          'flex-direction': 'row',
           'overflow-y': 'hidden',
           'max-height': `${workspace.cell.height * visibleOptions}px`,
         }}
       >
-        {options.map(({ text, menu, kind }, id) => (
-          <RowComplete active={id === ix}>
-            <div
-              style={{
-                display: 'flex',
-                // TODO: this doesn't scale with font size?
-                width: '24px',
-                'margin-right': '2px',
-                'align-items': 'center',
-                'justify-content': 'center',
-              }}
-            >
-              {getCompletionIcon(kind)}
-            </div>
-            <div>{text}</div>
-            <div style='margin-left:30px'>{menu}</div>
-          </RowComplete>
-        ))}
+        <div>
+          {options.map(({ text, kind }, id) => (
+            <RowComplete active={id === ix}>
+              <div
+                style={{
+                  display: 'flex',
+                  // TODO: this doesn't scale with font size?
+                  width: '24px',
+                  'margin-right': '2px',
+                  'align-items': 'center',
+                  'justify-content': 'center',
+                }}
+              >
+                {getCompletionIcon(kind)}
+              </div>
+              <div>{text}</div>
+            </RowComplete>
+          ))}
+        </div>
+
+        <div>
+          {options.map(({ menu }, id) => (
+            <RowComplete active={id === ix}>
+              <div>{menu}</div>
+            </RowComplete>
+          ))}
+        </div>
       </div>
       {documentation && (
         <div id='autocopmlete-docs-sup-yo'>{docs(documentation)}</div>

--- a/src/components/nvim/autocomplete.tsx
+++ b/src/components/nvim/autocomplete.tsx
@@ -120,6 +120,7 @@ let state = {
 
 type S = typeof state
 
+// https://github.com/veonim/veonim/blob/f780b7fc8079755ecac65b475eee3c6358857696/src/components/autocomplete.ts#L34-L36
 const pos: { container: ClientRect } = {
   container: { left: 0, right: 0, bottom: 0, top: 0, height: 0, width: 0 },
 }
@@ -234,6 +235,7 @@ const Autocomplete = ({
           'max-height': `${workspace.cell.height * visibleOptions}px`,
         }}
         ref={(e: any) => {
+          // https://github.com/veonim/veonim/blob/f780b7fc8079755ecac65b475eee3c6358857696/src/components/autocomplete.ts#L146
           if (e) pos.container = e.getBoundingClientRect()
         }}
       >
@@ -245,6 +247,7 @@ const Autocomplete = ({
                   id === ix ? cvar('foreground-b20') : cvar('foreground-30'),
               }}
               ref={(e: any) => {
+                // https://github.com/veonim/veonim/blob/f780b7fc8079755ecac65b475eee3c6358857696/src/components/autocomplete.ts#L156
                 if (id !== ix || !e) return
                 const { top, bottom } = e.getBoundingClientRect()
                 if (top < pos.container.top) return e.scrollIntoView(true)

--- a/src/components/nvim/autocomplete.tsx
+++ b/src/components/nvim/autocomplete.tsx
@@ -128,7 +128,11 @@ const pos: { container: ClientRect } = {
 const icon = (name: string, color?: string) => {
   return (
     <Icon
-      iconHtml={feather.icons[name].toSvg({ width: 12, height: 12 })}
+      iconHtml={feather.icons[name].toSvg({
+        width: workspace.font.size - 1,
+        height: workspace.font.size - 2,
+        viewBox: '0 0 24 26',
+      })}
       style={{ color }}
     />
   )

--- a/src/components/nvim/autocomplete.tsx
+++ b/src/components/nvim/autocomplete.tsx
@@ -189,7 +189,7 @@ const docs = (data: string) => (
       background: cvar('background-30'),
       'padding-top': '6px',
       'white-space': 'normal',
-      'font-size': `${workspace.font.size - 2}px`,
+      'font-size': `${workspace.font.size - 1}px`,
     }}
   />
 )
@@ -197,7 +197,7 @@ const docs = (data: string) => (
 const tdStyle = (): CSSProperties => ({
   'padding-right': '16px',
   'font-family': 'var(--font)',
-  'font-size': `${workspace.font.size - 2}px`,
+  'font-size': `${workspace.font.size - 1}px`,
 })
 
 const Autocomplete = ({

--- a/src/components/nvim/autocomplete.tsx
+++ b/src/components/nvim/autocomplete.tsx
@@ -170,7 +170,7 @@ const parseDocs = (docs?: string): string | undefined => {
 const docs = (data: string) => (
   // @ts-ignore TS wants children but there are none so ignore
   <RowNormal
-    dangerouslySetInnerHtml={`<div class=${resetMarkdownHTMLStyle}>${data}</div>`}
+    dangerouslySetInnerHTML={{ __html: `<div class=${resetMarkdownHTMLStyle}>${data}</div>`}}
     active={false}
     style={{
       ...paddingVH(6, 4),

--- a/src/components/nvim/autocomplete.tsx
+++ b/src/components/nvim/autocomplete.tsx
@@ -280,19 +280,15 @@ export const show = ({ row, col, options }: CompletionShow) => {
   const visibleOptions = Math.min(MAX_VISIBLE_OPTIONS, options.length)
   const anchorAbove = cursor.row + visibleOptions > workspace.size.rows
 
-  // TODO(smolck): Feels too imperative
-  state.visibleOptions = visibleOptions
-  state.anchorAbove = anchorAbove
-  state.options = options
-  const { x, y } = windows.pixelPosition(anchorAbove ? row : row + 1, col)
-  state.x = x
-  state.y = y
-  state.options = options.slice(0, visibleOptions)
-  state.visible = true
-  state.documentation = undefined
-  // TODO(smolck)
-  // default
-  state.ix = -1
+  Object.assign(state, {
+    visibleOptions,
+    anchorAbove,
+    options: options.slice(0, visibleOptions),
+    documentation: undefined,
+    visible: true,
+    ix: -1,
+    ...windows.pixelPosition(anchorAbove ? row : row + 1, col)
+  })
 
   render(<Autocomplete {...state} />, container)
 }

--- a/src/components/nvim/autocomplete.tsx
+++ b/src/components/nvim/autocomplete.tsx
@@ -105,7 +105,7 @@ export enum CompletionItemKind {
   TypeParameter = 24,
 }
 
-const MAX_VISIBLE_OPTIONS = 12
+const MAX_VISIBLE_OPTIONS = 20
 
 let state = {
   x: 0,
@@ -186,7 +186,7 @@ const docs = (data: string) => (
       display: 'block',
       overflow: 'visible',
       color: cvar('foreground-b20'),
-      background: cvar('background-10'),
+      background: cvar('background-30'),
       'padding-top': '6px',
       'white-space': 'normal',
       'font-size': `${workspace.font.size - 2}px`,
@@ -196,9 +196,8 @@ const docs = (data: string) => (
 
 const tdStyle: CSSProperties = {
   'padding-right': '16px',
-  'line-height': cvar('line-height'),
   'font-family': 'var(--font)',
-  'font-size': 'var(--font-size)px',
+  'font-size': `${workspace.font.size}px`,
 }
 
 const Autocomplete = ({
@@ -245,6 +244,8 @@ const Autocomplete = ({
               style={{
                 color:
                   id === ix ? cvar('foreground-b20') : cvar('foreground-30'),
+                background:
+                  id === ix ? cvar('background-10') : cvar('background-30'),
               }}
               ref={(e: any) => {
                 // https://github.com/veonim/veonim/blob/f780b7fc8079755ecac65b475eee3c6358857696/src/components/autocomplete.ts#L156

--- a/src/components/nvim/autocomplete.tsx
+++ b/src/components/nvim/autocomplete.tsx
@@ -21,6 +21,7 @@ export interface CompletionShow {
 export interface CompletionOption {
   /** Display text for the UI */
   text: string
+  menu: string
   /** Text that will be inserted in the buffer */
   insertText: string
   /** An enum used to display a fancy icon and color in the completion menu UI */
@@ -213,7 +214,7 @@ const Autocomplete = ({
         'max-height': `${workspace.cell.height * visibleOptions}px`,
       }}
     >
-      {options.map(({ text, kind }, id) => (
+      {options.map(({ text, menu, kind }, id) => (
         <RowComplete active={id === ix}>
           <div
             style={{
@@ -228,6 +229,7 @@ const Autocomplete = ({
             {getCompletionIcon(kind)}
           </div>
           <div>{text}</div>
+          <div style="margin-left:30px">{menu}</div>
         </RowComplete>
       ))}
     </div>
@@ -301,7 +303,8 @@ dispatch.sub('pmenu.show', ({ items, index, row, col }: PopupMenu) => {
   const options = items.map(
     (m) =>
       ({
-        text: `${m.word} ${m.menu}`,
+        text: m.word,
+        menu: m.menu,
         insertText: m.word,
         kind: stringToKind(m.kind),
         raw: {

--- a/src/components/nvim/autocomplete.tsx
+++ b/src/components/nvim/autocomplete.tsx
@@ -238,7 +238,13 @@ const Autocomplete = ({
           if (e) pos.container = e.getBoundingClientRect()
         }}
       >
-        <table style={{ overflow: 'hidden' }}>
+        <table
+          style={{
+            overflow: 'hidden',
+            padding: '4px 0px 4px 4px',
+            'border-spacing': 0,
+          }}
+        >
           {options.map(({ text, kind, menu }, id) => (
             <tr
               style={{

--- a/src/components/nvim/autocomplete.tsx
+++ b/src/components/nvim/autocomplete.tsx
@@ -194,11 +194,11 @@ const docs = (data: string) => (
   />
 )
 
-const tdStyle: CSSProperties = {
+const tdStyle = (): CSSProperties => ({
   'padding-right': '16px',
   'font-family': 'var(--font)',
-  'font-size': `${workspace.font.size}px`,
-}
+  'font-size': `${workspace.font.size - 2}px`,
+})
 
 const Autocomplete = ({
   documentation,
@@ -267,8 +267,8 @@ const Autocomplete = ({
               >
                 {getCompletionIcon(kind)}
               </td>
-              <td style={tdStyle}>{text}</td>
-              <td style={tdStyle}>{menu}</td>
+              <td style={tdStyle()}>{text}</td>
+              <td style={tdStyle()}>{menu}</td>
             </tr>
           ))}
         </table>

--- a/src/components/nvim/autocomplete.tsx
+++ b/src/components/nvim/autocomplete.tsx
@@ -193,7 +193,7 @@ const docs = (data: string) => (
       background: cvar('background-30'),
       'padding-top': '6px',
       'white-space': 'normal',
-      'font-size': `${workspace.font.size - 1}px`,
+      'font-size': `${workspace.font.size * 0.9}px`,
     }}
   />
 )
@@ -201,7 +201,7 @@ const docs = (data: string) => (
 const tdStyle = (): CSSProperties => ({
   'padding-right': '16px',
   'font-family': 'var(--font)',
-  'font-size': `${workspace.font.size - 1}px`,
+  'font-size': `${workspace.font.size * 0.9}px`,
 })
 
 const Autocomplete = ({

--- a/src/components/nvim/autocomplete.tsx
+++ b/src/components/nvim/autocomplete.tsx
@@ -256,7 +256,7 @@ const Autocomplete = ({
         </table>
       </div>
       {documentation && (
-        <div id='autocopmlete-docs-sup-yo'>{docs(documentation)}</div>
+        <div>{docs(documentation)}</div>
       )}
     </div>
   </Overlay>

--- a/src/components/nvim/autocomplete.tsx
+++ b/src/components/nvim/autocomplete.tsx
@@ -190,7 +190,7 @@ const docs = (data: string) => (
 )
 
 const tdStyle: CSSProperties = {
-  'padding-right': '8px',
+  'padding-right': '16px',
   'line-height': cvar('line-height'),
   'font-family': 'var(--font)',
   'font-size': 'var(--font-size)px',


### PR DESCRIPTION
Basically, take care of #10 

- [X] In the TUI, word and menu are printed in separate columns; would be nice to have this for the external menu as well.

- [x] Menu only shows a subset of entries but does not scroll if end is reached.
 
- [ ] Some characters (!, #, etc.) are shown as numbers instead? (Due to https://github.com/smolck/uivonim/issues/24#issuecomment-711555423 -- "strings as raw bytes, and use the ascii/unicode byte numbers as an index to a font glyph atlas in WebGL"? Or some other reason?)

- [ ] Image support (e.g., from markdown strings) in the documentation window