### PR TITLE
Improve redraw event handling

### DIFF
--- a/src/render/redraw.ts
+++ b/src/render/redraw.ts
@@ -313,6 +313,7 @@ const refreshOrStartLayoutTimer = (winUpdates: boolean) => {
   layoutTimeout = setTimeout(() => {
     renderEvents.messageClearPromptsMaybeHack(state_cursorVisible)
     state_cursorVisible ? showCursor() : hideCursor()
+    if (state_cursorVisible) updateCursorChar()
     dispatch.pub('redraw')
     if (!winUpdates) return
 

--- a/src/render/redraw.ts
+++ b/src/render/redraw.ts
@@ -307,6 +307,20 @@ const win_float_pos = (e: any) => {
   }
 }
 
+let layoutTimeout: NodeJS.Timeout | undefined
+
+const refreshOrStartLayoutTimer = (winUpdates: boolean) => {
+  layoutTimeout = setTimeout(() => {
+    renderEvents.messageClearPromptsMaybeHack(state_cursorVisible)
+    state_cursorVisible ? showCursor() : hideCursor()
+    dispatch.pub('redraw')
+    if (!winUpdates) return
+
+    windows.disposeInvalidWindows()
+    windows.layout()
+  }, 10)
+}
+
 onRedraw((redrawEvents) => {
   // because of circular logic/infinite loop. cmdline_show updates UI, UI makes
   // a change in the cmdline, nvim sends redraw again. we cut that stuff out
@@ -371,14 +385,6 @@ onRedraw((redrawEvents) => {
     else if (e === 'msg_ruler') renderEvents.msg_ruler(ev)
   }
 
-  renderEvents.messageClearPromptsMaybeHack(state_cursorVisible)
-
-  requestAnimationFrame(() => {
-    state_cursorVisible ? showCursor() : hideCursor()
-    if (state_cursorVisible) updateCursorChar()
-    dispatch.pub('redraw')
-    if (!winUpdates) return
-    windows.disposeInvalidWindows()
-    windows.layout()
-  })
+  if (layoutTimeout) clearTimeout(layoutTimeout)
+  refreshOrStartLayoutTimer(winUpdates)
 })


### PR DESCRIPTION
Not the greatest/most descriptive PR name (or branch name tbh), but not too terribly worried about that; implements patch based on info from https://github.com/smolck/uivonim/issues/24#issuecomment-720015922 and surrounding comments. Should make things more performant, although don't have any concrete proof of that. Anecdotally, though, I would say it definitely feels faster ;)

Not entirely done yet, I think it still needs to deal with the way redraw events such as `win_float_pos` are handled; atm DOM things, for example adding a window, are done immediately after the redraw event is received, when that should maybe all be done at once in the `layoutTimeout` call? Not sure yet.