### PR TITLE
ci: remove master branch trigger on push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - v*
-    branches: [master]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The different event types are independent of each other, so in this case
the workflow was run for pushes on master or pushes with v* tag. Now
it's only the version tag that triggers the workflow.